### PR TITLE
remove jetify from android build step

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,9 +113,9 @@ end
 # options is wat je meegeeft bij het aanroepen van public lane (zie hierboven)
 private_lane :build_android do |options|
   if options[:buildType] == "release" then
-    sh "(cd ../ && npx jetify;); cd ../android/; ENVFILE=.env ./gradlew clean app:assemble#{options[:buildType]}" # stap kan weg als we .env.release maken bvb
+    sh "cd ../android/; ENVFILE=.env ./gradlew clean app:assemble#{options[:buildType]}" # stap kan weg als we .env.release maken bvb
   else
-    sh "(cd ../ && npx jetify;); cd ../android/; ENVFILE=.env.#{options[:buildType]} ./gradlew clean app:assemble#{options[:buildType]}"
+    sh "cd ../android/; ENVFILE=.env.#{options[:buildType]} ./gradlew clean app:assemble#{options[:buildType]}"
   end
 end
 


### PR DESCRIPTION
Note that jetifier is included and ran automatically with react-native-community/cli for React Native versions 0.60 and above, so you do not need to install and run jetifier manually.