### PR TITLE
Inline links in family onboarding screen

### DIFF
--- a/src/_translations/locales/nl.json
+++ b/src/_translations/locales/nl.json
@@ -24,10 +24,10 @@
     "CONFIRM": "Doorgaan",
     "FAMILY": {
       "TITLE": "Wil je de UiTPAS app met je hele gezin gebruiken?",
-      "BULLET_1": "Beheer nu alle UiTPASSen van al jouw gezinsleden op 1 plek",
-      "BULLET_2": "Spaar UiTPAS punten voor je hele gezin in één keer",
-      "BULLET_3": "Ruil voordelen om voor al je gezinleden in dezelfde app",
-      "BULLET_4": "Bekijk de historiek van jou en je gezinsleden",
+      "BULLET_1_TEXT": "Beheer nu alle UiTPASSen van al jouw gezinsleden op 1 plek",
+      "BULLET_2_TEXT": "Spaar UiTPAS punten voor je hele gezin in één keer",
+      "BULLET_3_TEXT": "Ruil voordelen om voor al je gezinleden in dezelfde app",
+      "BULLET_4_TEXT": "Bekijk de historiek van jou en je gezinsleden",
       "CONFIRM": "Ja, stel mijn gezin samen",
       "SKIP": "Nee, voorlopig niet",
       "OVERVIEW": {

--- a/src/onboarding/family/FamilyOnboarding.tsx
+++ b/src/onboarding/family/FamilyOnboarding.tsx
@@ -3,19 +3,20 @@ import { useTranslation } from 'react-i18next';
 import { Platform } from 'react-native';
 
 import { Family } from '../../_assets/images';
-import { Button, SafeAreaView, Spinner, Typography } from '../../_components';
+import { Button, SafeAreaView, Spinner, Trans } from '../../_components';
 import { useOnboarding } from '../../_context';
 import { StorageKey } from '../../_models';
 import { TMainNavigationProp } from '../../_routing';
 import { storage } from '../../storage';
 import { useHasFamilyMembers } from './_queries';
 import * as Styled from './style';
+import { openExternalURL } from '../../_utils';
 
 const BULLET_ITEMS = [
-  { text: 'ONBOARDING.FAMILY.BULLET_1' },
-  { text: 'ONBOARDING.FAMILY.BULLET_2' },
-  { text: 'ONBOARDING.FAMILY.BULLET_3' },
-  { text: 'ONBOARDING.FAMILY.BULLET_4' },
+  { textKey: 'ONBOARDING.FAMILY.BULLET_1_TEXT' },
+  { textKey: 'ONBOARDING.FAMILY.BULLET_2_TEXT' },
+  { textKey: 'ONBOARDING.FAMILY.BULLET_3_TEXT' },
+  { textKey: 'ONBOARDING.FAMILY.BULLET_4_TEXT' },
 ];
 
 type TProps = {
@@ -56,9 +57,13 @@ export const FamilyOnboarding = ({ navigation }: TProps) => {
         </Styled.Title>
         <Styled.Hero source={Family} />
         <Styled.BulletList>
-          {BULLET_ITEMS.map(({ text }, index) => (
+          {BULLET_ITEMS.map(({ textKey }, index) => (
             <Styled.BulletListItem key={index}>
-              <Typography>{t(text)}</Typography>
+              <Trans
+                i18nKey={textKey}
+                onButtonPress={() => openExternalURL(t(`ONBOARDING.FAMILY.BULLET_${index + 1}_LINK`))}
+                selectable
+              />
             </Styled.BulletListItem>
           ))}
         </Styled.BulletList>


### PR DESCRIPTION
![Simulator Screenshot - iPhone 15 - 2023-11-30 at 17 49 30](https://github.com/cultuurnet/uitpas-mobile-app/assets/5648493/2ac689ec-1d9d-4e1a-b848-dab77605e535)

Example usage in translations:
```
"BULLET_4_TEXT": "Bekijk de historiek van jou en <button>je gezinsleden</button>",
"BULLET_4_LINK": "https://www.uitpas.be/privacybeleid"
```

Current solution allows only one link per bullet item, I believe there might be a cleaner solution available. I'm open to suggestions for improvement.